### PR TITLE
Bump mypy pre-commit hook to v1.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: wazo-copyright-check
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.19.1
     hooks:
       - id: mypy
         language_version: "3.11"


### PR DESCRIPTION
Resolves compatibility issues with latest types-setuptools.
See WAZO-4386.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Upgrade mypy pre-commit hook**
> 
> - Bumps `mypy` in `.pre-commit-config.yaml` from `v1.7.1` to `v1.19.1` (Python `3.11` remains)
> - Addresses compatibility with latest `types-setuptools`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77065c9573f2d72039506bb9f9e488c64235f99d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->